### PR TITLE
Limit rebuild scenarios

### DIFF
--- a/.tekton/git-clone-pull-request.yaml
+++ b/.tekton/git-clone-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ("git-clone".pathChanged() || "Dockerfile".pathChanged() || ".tekton".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: git-clone

--- a/.tekton/git-clone-push.yaml
+++ b/.tekton/git-clone-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ("git-clone".pathChanged() || "Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: git-clone


### PR DESCRIPTION
We don't need to rebuild when the README or CODEOWNERS files change.