### PR TITLE
chore(tekton): enable proxy cache

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -95,7 +95,7 @@ spec:
     type: string
     description: The format for the resulting image's mediaType. Valid values are oci or docker.
   - name: enable-cache-proxy
-    default: 'false'
+    default: 'true'
     description: Enable cache proxy configuration
     type: string
   results:


### PR DESCRIPTION
Enable proxy cache for images

## Summary by Sourcery

Build:
- Set the Tekton build pipeline parameter `enable-cache-proxy` default to true to turn on image cache proxying.