### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecation notice
+
+This repository is deprecated and is not maintained any more.
+Current git clone task uses [task-runner](https://github.com/konflux-ci/task-runner) image as the base image.
+If you use the [git-clone](https://quay.io/repository/konflux-ci/git-clone) image, please switch to the [task-runner](https://quay.io/repository/konflux-ci/task-runner) image.
+
 # git-clone
 
 Konflux build of Tekton's [git-clone utility](https://github.com/tektoncd-catalog/git-clone/tree/main/image/git-init)


### PR DESCRIPTION
Deprecate this repository in favor of [task-runner](https://github.com/konflux-ci/task-runner).

## Summary by Sourcery

Documentation:
- Document that the repository is deprecated and recommend switching from the git-clone image to the task-runner image.